### PR TITLE
Add CI for Android Build in GitHub Actions

### DIFF
--- a/.github/workflows/androidBuild.yml
+++ b/.github/workflows/androidBuild.yml
@@ -18,16 +18,13 @@ jobs:
         uses: actions/setup-java@v4.0.0
         with:
           java-version: '17'
-          distribution: 'adopt'
-
+          distribution: 'temurin'
+          
       - name: Change wrapper permissions
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-      
-        with:
-          path: android/
-        run: ./android/gradlew build
+        run: cd android && ./gradlew build
 
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.3

--- a/.github/workflows/androidBuild.yml
+++ b/.github/workflows/androidBuild.yml
@@ -1,0 +1,36 @@
+name: Android Build
+
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4.0.0
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Change wrapper permissions
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+      
+        with:
+          path: android/
+        run: ./android/gradlew build
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: REGTA.apk
+          path: android/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/androidBuild.yml
+++ b/.github/workflows/androidBuild.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'temurin'
           
       - name: Change wrapper permissions
-        run: chmod +x ./gradlew
+        run: cd android && chmod +x ./gradlew
 
       - name: Build with Gradle
         run: cd android && ./gradlew build


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automate the Android app build process. Now, whenever there is a push or pull request to the main branch, CI will:

- Checkout the code
- Set up the Java environment (JDK 17)
- Grant Gradle Wrapper permissions
- Run the build with Gradle
- Upload the generated APK as an artifact